### PR TITLE
Feat/basemapper bytesio geojson

### DIFF
--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -29,6 +29,7 @@ import threading
 from pathlib import Path
 from typing import Union
 
+from io import BytesIO
 import geojson
 import mercantile
 from cpuinfo import get_cpu_info
@@ -282,8 +283,40 @@ class BaseMapper(object):
 
         Returns:
             (list): The bounding box coordinates
-        """
-        if not boundary.lower().endswith((".json", ".geojson")):
+        """ 
+
+        if isinstance(boundary, BytesIO):
+            # Convert bytes to GeoJSON 
+            try: 
+                boundary.seek(0)
+                byte_string = boundary.read().decode('utf-8')
+                poly = geojson.loads(byte_string)
+            except Exception as e:
+                print("Error occured while converting bytes to GeoJSON: ", e)
+
+            if "features" in poly:
+                geometry = shape(poly["features"][0]["geometry"])
+            elif "geometry" in poly:
+                geometry = shape(poly["geometry"])
+            else:
+                geometry = shape(poly)
+
+            if isinstance(geometry, list):
+                # Multiple geometries
+                log.debug("Creating union of multiple bbox geoms")
+                geometry = unary_union(geometry)
+
+            if geometry.is_empty:
+                msg = f"No bbox extracted from {geometry}"
+                log.error(msg)
+                raise ValueError(msg) from None
+
+            bbox = geometry.bounds
+            # left, bottom, right, top
+            # minX, minY, maxX, maxY
+            return bbox
+
+        else: 
             # Is BBOX string
             try:
                 if "," in boundary:
@@ -303,32 +336,7 @@ class BaseMapper(object):
                 msg = f"Failed to parse BBOX string: {boundary}"
                 log.error(msg)
                 raise ValueError(msg) from None
-
-        log.debug(f"Reading geojson file: {boundary}")
-        with open(boundary, "r") as f:
-            poly = geojson.load(f)
-        if "features" in poly:
-            geometry = shape(poly["features"][0]["geometry"])
-        elif "geometry" in poly:
-            geometry = shape(poly["geometry"])
-        else:
-            geometry = shape(poly)
-
-        if isinstance(geometry, list):
-            # Multiple geometries
-            log.debug("Creating union of multiple bbox geoms")
-            geometry = unary_union(geometry)
-
-        if geometry.is_empty:
-            msg = f"No bbox extracted from {geometry}"
-            log.error(msg)
-            raise ValueError(msg) from None
-
-        bbox = geometry.bounds
-        # left, bottom, right, top
-        # minX, minY, maxX, maxY
-        return bbox
-
+        
 
 def tileid_from_y_tile(filepath: Union[Path | str]):
     """Helper function to get the tile id from a tile in z/x/y directory structure.
@@ -532,8 +540,13 @@ def create_basemap_file(
 
 def main():
     """This main function lets this class be run standalone by a bash script."""
-    parser = argparse.ArgumentParser(description="Create an tile basemap for ODK Collect")
+    parser = argparse.ArgumentParser(description="Create a tile basemap for ODK Collect")
+
+    # An optional flag to enable verbose output
     parser.add_argument("-v", "--verbose", action="store_true", help="verbose output")
+
+    # Required argument specifying the boundary for the area of interest.
+    # It accepts either a path to a GeoJSON file or a bounding box string in the format 'min_x min_y max_x max_y' 
     parser.add_argument(
         "-b",
         "--boundary",
@@ -543,13 +556,25 @@ def main():
             "The boundary for the area you want. " "Accepts path to geojson file or bbox string. " "Format min_x min_y max_x max_y"
         ),
     )
+
+    # Optional argument for specifying a custom TMS (Tile Map Service) URL.
     parser.add_argument("-t", "--tms", help="Custom TMS URL")
+    
+    # Optional argument to indicate whether to swap the X & Y coordinates when using a custom TMS.
     parser.add_argument("--xy", default=False, help="Swap the X & Y coordinates when using a custom TMS")
+    
+    # Optional argument specifying the output file name for the basemap. 
     parser.add_argument(
         "-o", "--outfile", required=False, help="Output file name, allowed extensions [.mbtiles/.sqlitedb/.pmtiles]"
     )
+
+    # Optional argument specifying the zoom levels for the basemap. Default is set to 12-17.
     parser.add_argument("-z", "--zooms", default="12-17", help="The Zoom levels")
+
+    # Optional argument specifying the output directory name for the tile cache.
     parser.add_argument("-d", "--outdir", help="Output directory name for tile cache")
+
+    # Optional argument specifying the imagery source. Valid choices are esri, bing, topo, google, and oam.
     parser.add_argument(
         "-s",
         "--source",
@@ -557,8 +582,21 @@ def main():
         choices=["esri", "bing", "topo", "google", "oam"],
         help="Imagery source",
     )
+
+    parser.add_argument("--config", help="Additional configuration as a dictionary")
+
     args = parser.parse_args()
 
+    if args.config:
+        print(args.config)
+        # import json
+        # try:
+        #     config = json.loads(args.config)
+        # except json.JSONDecodeError as e:
+        #     print("Error decoding config JSON:", e)
+        #     return
+
+    # Argument Validations
     if not args.boundary:
         log.error("You need to specify a boundary! (file or bbox)")
         parser.print_help()
@@ -576,7 +614,12 @@ def main():
             log.error("")
             parser.print_help()
             quit()
-        boundary_parsed = args.boundary[0]
+
+        with open(args.boundary[0], "rb") as geojson_file:
+            boundary = geojson_file.read()  # read as a `bytes` object.
+            boundary_parsed = BytesIO(boundary)   # add to a BytesIO wrapper
+        
+        # boundary_parsed = args.boundary[0]
     elif len(args.boundary) == 4:
         boundary_parsed = ",".join(args.boundary)
     else:
@@ -586,6 +629,7 @@ def main():
         parser.print_help()
         quit()
 
+    # Responsible for generating the basemap using the specified parameters
     create_basemap_file(
         verbose=args.verbose,
         boundary=boundary_parsed,

--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -283,13 +283,13 @@ class BaseMapper(object):
 
         Returns:
             (list): The bounding box coordinates
-        """ 
+        """
 
         if isinstance(boundary, BytesIO):
-            # Convert bytes to GeoJSON 
-            try: 
+            # Convert bytes to GeoJSON
+            try:
                 boundary.seek(0)
-                byte_string = boundary.read().decode('utf-8')
+                byte_string = boundary.read().decode("utf-8")
                 poly = geojson.loads(byte_string)
             except Exception as e:
                 print("Error occured while converting bytes to GeoJSON: ", e)
@@ -316,7 +316,7 @@ class BaseMapper(object):
             # minX, minY, maxX, maxY
             return bbox
 
-        else: 
+        else:
             # Is BBOX string
             try:
                 if "," in boundary:
@@ -336,7 +336,7 @@ class BaseMapper(object):
                 msg = f"Failed to parse BBOX string: {boundary}"
                 log.error(msg)
                 raise ValueError(msg) from None
-        
+
 
 def tileid_from_y_tile(filepath: Union[Path | str]):
     """Helper function to get the tile id from a tile in z/x/y directory structure.
@@ -546,7 +546,7 @@ def main():
     parser.add_argument("-v", "--verbose", action="store_true", help="verbose output")
 
     # Required argument specifying the boundary for the area of interest.
-    # It accepts either a path to a GeoJSON file or a bounding box string in the format 'min_x min_y max_x max_y' 
+    # It accepts either a path to a GeoJSON file or a bounding box string in the format 'min_x min_y max_x max_y'
     parser.add_argument(
         "-b",
         "--boundary",
@@ -559,11 +559,11 @@ def main():
 
     # Optional argument for specifying a custom TMS (Tile Map Service) URL.
     parser.add_argument("-t", "--tms", help="Custom TMS URL")
-    
+
     # Optional argument to indicate whether to swap the X & Y coordinates when using a custom TMS.
     parser.add_argument("--xy", default=False, help="Swap the X & Y coordinates when using a custom TMS")
-    
-    # Optional argument specifying the output file name for the basemap. 
+
+    # Optional argument specifying the output file name for the basemap.
     parser.add_argument(
         "-o", "--outfile", required=False, help="Output file name, allowed extensions [.mbtiles/.sqlitedb/.pmtiles]"
     )
@@ -589,12 +589,6 @@ def main():
 
     if args.config:
         print(args.config)
-        # import json
-        # try:
-        #     config = json.loads(args.config)
-        # except json.JSONDecodeError as e:
-        #     print("Error decoding config JSON:", e)
-        #     return
 
     # Argument Validations
     if not args.boundary:
@@ -617,8 +611,8 @@ def main():
 
         with open(args.boundary[0], "rb") as geojson_file:
             boundary = geojson_file.read()  # read as a `bytes` object.
-            boundary_parsed = BytesIO(boundary)   # add to a BytesIO wrapper
-        
+            boundary_parsed = BytesIO(boundary)  # add to a BytesIO wrapper
+
         # boundary_parsed = args.boundary[0]
     elif len(args.boundary) == 4:
         boundary_parsed = ",".join(args.boundary)

--- a/osm_fieldwork/outreachy.py
+++ b/osm_fieldwork/outreachy.py
@@ -1,0 +1,14 @@
+from io import BytesIO
+from osm_fieldwork.basemapper import create_basemap_file
+
+with open("osm_fieldwork\\geo.geojson", "rb") as geojson_file:
+    boundary = geojson_file.read() 
+    boundary_bytesio = BytesIO(boundary)   # add to a BytesIO wrapper
+
+create_basemap_file(
+    verbose=True,
+    boundary=boundary_bytesio,
+    outfile="outreachy.mbtiles",
+    zooms="12-15",
+    source="esri",
+)

--- a/osm_fieldwork/outreachy.py
+++ b/osm_fieldwork/outreachy.py
@@ -2,8 +2,8 @@ from io import BytesIO
 from osm_fieldwork.basemapper import create_basemap_file
 
 with open("osm_fieldwork\\..\\tests\\testdata\\Rollinsville.geojson", "rb") as geojson_file:
-    boundary = geojson_file.read() 
-    boundary_bytesio = BytesIO(boundary)   # add to a BytesIO wrapper
+    boundary = geojson_file.read()
+    boundary_bytesio = BytesIO(boundary)  # add to a BytesIO wrapper
 
 create_basemap_file(
     verbose=True,

--- a/osm_fieldwork/outreachy.py
+++ b/osm_fieldwork/outreachy.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 from osm_fieldwork.basemapper import create_basemap_file
 
-with open("osm_fieldwork\\geo.geojson", "rb") as geojson_file:
+with open("osm_fieldwork\\..\\tests\\testdata\\Rollinsville.geojson", "rb") as geojson_file:
     boundary = geojson_file.read() 
     boundary_bytesio = BytesIO(boundary)   # add to a BytesIO wrapper
 

--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -33,12 +33,11 @@ rootdir = os.path.dirname(os.path.abspath(__file__))
 boundary_file = f"{rootdir}/testdata/Rollinsville.geojson"
 
 with open(boundary_file, "rb") as geojson_file:
-    boundary = geojson_file.read() 
+    boundary = geojson_file.read()
 boundary = BytesIO(boundary)
 
 outfile = f"{rootdir}/testdata/rollinsville.mbtiles"
 base = "./tiles"
-
 
 
 def test_create():
@@ -64,7 +63,7 @@ def test_create():
     outf.db = None
     outf.cursor = None
 
-    os.remove(outfile) 
+    os.remove(outfile)
     shutil.rmtree(base)
 
     assert hits == 2
@@ -90,6 +89,7 @@ def clear_out_dir():
 
 # Test create_basemap_file with Bbox Coordinates
 
+
 def test_bbox_coords():
     boundary = "-4.730494, 41.650541, -4.725634, 41.652874"
 
@@ -104,21 +104,22 @@ def test_bbox_coords():
 
     assert os.listdir(base), "No files were downloaded in the directory"
     assert os.path.isfile(outfile), "Output file not created"
-    
+
     clear_out_dir()
 
     print("Test passed with boundary passed as coordinates \n")
-    
+
 
 # Test create_basemap_file with GeoJSON BytesIOWrapped file
+
 
 def test_in_memory_geojson():
     boundary_file = f"{rootdir}/testdata/Rollinsville.geojson"
 
     with open(boundary_file, "rb") as geojson_file:
-        boundary = geojson_file.read() 
-    
-    boundary = BytesIO(boundary)   # add to a BytesIO wrapper
+        boundary = geojson_file.read()
+
+    boundary = BytesIO(boundary)  # add to a BytesIO wrapper
 
     create_basemap_file(
         verbose=True,
@@ -131,9 +132,9 @@ def test_in_memory_geojson():
 
     assert os.listdir(base), "No files were downloaded in the directory"
     assert os.path.isfile(outfile), "Output file not created"
-    
+
     clear_out_dir()
-    
+
     print("Test passed with boundary passed as BytesIO wrapped file \n")
 
 
@@ -142,5 +143,5 @@ if __name__ == "__main__":
     test_create()
 
     test_bbox_coords()
-    
+
     test_in_memory_geojson()


### PR DESCRIPTION
**GeoJSON Support in Basemapper Module**

This pull request resolves issue #204 by augmenting the functionality of the basemapper.py module. The enhancement enables the passing of GeoJSON data in-memory as a BytesIO object for the boundary parameter. Previously, the boundary parameter exclusively accepted either a bounding box string or a GeoJSON file on disk.

From the command line, users can now seamlessly provide a file path, which will be automatically converted into a bytes object before being passed to create_basemap_file. 

Furthermore, this update includes the addition of test cases to ensure the reliability and robustness of the implementation.